### PR TITLE
Add say fallback with gTTS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyPDF2>=3.0.0
 pydub>=0.25.1
 setuptools>=65.0.0
+gTTS>=2.5.1


### PR DESCRIPTION
## Summary
- check whether the native `say` command exists
- use gTTS as a fallback if `say` isn't available
- note the new dependency in requirements

## Testing
- `python -m py_compile pdf2mp3.py`


------
https://chatgpt.com/codex/tasks/task_e_6840539bf638832a81059bbfd0fd7965