### PR TITLE
Add simple web page interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,13 @@ The script will:
 
 ## GitHub Pages Web App
 
-A minimal web interface is available in the `docs/` folder. When hosted with GitHub Pages it lets you upload a PDF or paste text and converts it to an MP3 using the browser.
+A very small browser interface is included so you can convert files without installing anything. Enable GitHub Pages for the repository (either from the root or the `docs/` folder) and open:
 
-Open `https://<username>.github.io/audiobook_maker/` after enabling GitHub Pages for the repository.
+```
+https://<username>.github.io/audiobook_maker/
+```
+
+From there you can upload a PDF or paste text and click **Convert** to generate and download the MP3 directly in your browser.
 
 
 ## Note

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PDF/Text to MP3</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>PDF/Text to MP3 Converter</h1>
+  <p>Upload a PDF or paste text below and click <strong>Convert</strong>. Your MP3 will appear for playback and download.</p>
+
+  <div class="uploader">
+    <input type="file" id="pdfFile" accept="application/pdf">
+    <textarea id="textInput" placeholder="Or paste text here..."></textarea>
+    <button id="convertBtn">Convert</button>
+  </div>
+
+  <div id="progress"></div>
+  <audio id="audio" controls style="display:none;"></audio>
+  <a id="downloadLink" href="#" download="output.mp3" style="display:none;">Download MP3</a>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,70 @@
+async function extractTextFromPDF(file) {
+  const typedarray = new Uint8Array(await file.arrayBuffer());
+  const pdf = await pdfjsLib.getDocument({ data: typedarray }).promise;
+  let text = '';
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+    const page = await pdf.getPage(pageNum);
+    const content = await page.getTextContent();
+    const strings = content.items.map(item => item.str);
+    text += strings.join(' ') + '\n';
+  }
+  return text;
+}
+
+function chunkText(text, max = 200) {
+  const sentences = text.match(/[^.!?]+[.!?\n]*/g) || [];
+  const chunks = [];
+  let current = '';
+  for (const sentence of sentences) {
+    if ((current + sentence).length > max) {
+      chunks.push(current.trim());
+      current = sentence;
+    } else {
+      current += sentence;
+    }
+  }
+  if (current) chunks.push(current.trim());
+  return chunks;
+}
+
+async function fetchMP3(chunk) {
+  const url = `https://corsproxy.io/https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&tl=en-US&q=${encodeURIComponent(chunk)}`;
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error('TTS request failed');
+  return new Uint8Array(await resp.arrayBuffer());
+}
+
+async function textToMP3(text) {
+  const chunks = chunkText(text);
+  const buffers = [];
+  const progress = document.getElementById('progress');
+  for (let i = 0; i < chunks.length; i++) {
+    progress.textContent = `Fetching audio ${i + 1} / ${chunks.length}...`;
+    buffers.push(await fetchMP3(chunks[i]));
+  }
+  progress.textContent = 'Combining...';
+  const blob = new Blob(buffers, { type: 'audio/mpeg' });
+  const url = URL.createObjectURL(blob);
+  document.getElementById('audio').style.display = 'block';
+  document.getElementById('audio').src = url;
+  const dl = document.getElementById('downloadLink');
+  dl.href = url;
+  dl.style.display = 'inline-block';
+  progress.textContent = 'Done!';
+}
+
+async function handleConvert() {
+  const file = document.getElementById('pdfFile').files[0];
+  let text = document.getElementById('textInput').value.trim();
+  if (file) {
+    document.getElementById('progress').textContent = 'Extracting text from PDF...';
+    text += '\n' + await extractTextFromPDF(file);
+  }
+  if (!text) {
+    alert('Please upload a PDF or enter some text.');
+    return;
+  }
+  await textToMP3(text);
+}
+
+document.getElementById('convertBtn').addEventListener('click', handleConvert);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,23 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 1em;
+}
+
+.uploader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.uploader input,
+.uploader textarea,
+.uploader button {
+  font-size: 1rem;
+  width: 100%;
+}
+
+textarea {
+  min-height: 150px;
+}


### PR DESCRIPTION
## Summary
- provide a simple `index.html` page so the GitHub Pages site lets users upload PDFs or paste text
- add minimal styling so controls fill the width of the page
- copy the page script client side for convenience
- update README with instructions for the GitHub Pages web app

## Testing
- `python -m py_compile pdf2mp3.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68405dc008f8832a9aca9dc8c4b141fc