### PR TITLE
Add progress bar UI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
   </div>
 
   <div id="progress"></div>
+  <progress id="progressBar" value="0" max="100" style="display:none;"></progress>
   <audio id="audio" controls style="display:none;"></audio>
   <a id="downloadLink" href="#" download="output.mp3" style="display:none;">Download MP3</a>
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -38,11 +38,18 @@ async function textToMP3(text) {
   const chunks = chunkText(text);
   const buffers = [];
   const progress = document.getElementById('progress');
+  const progressBar = document.getElementById('progressBar');
+  progressBar.max = chunks.length;
+  progressBar.value = 0;
+  progressBar.style.display = 'block';
   for (let i = 0; i < chunks.length; i++) {
     progress.textContent = `Fetching audio ${i + 1} / ${chunks.length}...`;
+    progressBar.value = i;
     buffers.push(await fetchMP3(chunks[i]));
+    progressBar.value = i + 1;
   }
   progress.textContent = 'Combining...';
+  progressBar.value = progressBar.max;
   const blob = new Blob(buffers, { type: 'audio/mpeg' });
   const url = URL.createObjectURL(blob);
   document.getElementById('audio').style.display = 'block';
@@ -51,11 +58,15 @@ async function textToMP3(text) {
   dl.href = url;
   dl.style.display = 'inline-block';
   progress.textContent = 'Done!';
+  progressBar.style.display = 'none';
 }
 
 async function handleConvert() {
   const file = document.getElementById('pdfFile').files[0];
   let text = document.getElementById('textInput').value.trim();
+  const progressBar = document.getElementById('progressBar');
+  progressBar.style.display = 'none';
+  progressBar.value = 0;
   if (file) {
     document.getElementById('progress').textContent = 'Extracting text from PDF...';
     text += '\n' + await extractTextFromPDF(file);

--- a/docs/style.css
+++ b/docs/style.css
@@ -14,3 +14,9 @@ body {
 textarea {
   min-height: 150px;
 }
+
+#progressBar {
+  width: 100%;
+  margin-top: 0.5em;
+  display: none;
+}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   </div>
 
   <div id="progress"></div>
+  <progress id="progressBar" value="0" max="100" style="display:none;"></progress>
   <audio id="audio" controls style="display:none;"></audio>
   <a id="downloadLink" href="#" download="output.mp3" style="display:none;">Download MP3</a>
 

--- a/script.js
+++ b/script.js
@@ -38,11 +38,18 @@ async function textToMP3(text) {
   const chunks = chunkText(text);
   const buffers = [];
   const progress = document.getElementById('progress');
+  const progressBar = document.getElementById('progressBar');
+  progressBar.max = chunks.length;
+  progressBar.value = 0;
+  progressBar.style.display = 'block';
   for (let i = 0; i < chunks.length; i++) {
     progress.textContent = `Fetching audio ${i + 1} / ${chunks.length}...`;
+    progressBar.value = i;
     buffers.push(await fetchMP3(chunks[i]));
+    progressBar.value = i + 1;
   }
   progress.textContent = 'Combining...';
+  progressBar.value = progressBar.max;
   const blob = new Blob(buffers, { type: 'audio/mpeg' });
   const url = URL.createObjectURL(blob);
   document.getElementById('audio').style.display = 'block';
@@ -51,11 +58,15 @@ async function textToMP3(text) {
   dl.href = url;
   dl.style.display = 'inline-block';
   progress.textContent = 'Done!';
+  progressBar.style.display = 'none';
 }
 
 async function handleConvert() {
   const file = document.getElementById('pdfFile').files[0];
   let text = document.getElementById('textInput').value.trim();
+  const progressBar = document.getElementById('progressBar');
+  progressBar.style.display = 'none';
+  progressBar.value = 0;
   if (file) {
     document.getElementById('progress').textContent = 'Extracting text from PDF...';
     text += '\n' + await extractTextFromPDF(file);

--- a/style.css
+++ b/style.css
@@ -21,3 +21,9 @@ body {
 textarea {
   min-height: 150px;
 }
+
+#progressBar {
+  width: 100%;
+  margin-top: 0.5em;
+  display: none;
+}


### PR DESCRIPTION
## Summary
- add a `<progress>` element for audio fetch progress
- display and update the progress bar while generating MP3 audio
- hide the bar when finished
- mirror these changes in the docs build

## Testing
- `python -m py_compile pdf2mp3.py`

------
https://chatgpt.com/codex/tasks/task_e_68406f3e839c832ab0e0b0fec2e170d3