### PR TITLE
Allow setting output path for audiobook

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ brew install ffmpeg
 
 ## Usage
 
-Run the script by providing the path to your PDF file as an argument:
+Run the script by providing the path to your PDF file. You can optionally
+specify an output path for the generated MP3 using ``-o`` or ``--output``:
 
 ```bash
 # If the PDF is in the current directory:
 python pdf2mp3.py my_document.pdf
+
+# Specify a custom output location:
+python pdf2mp3.py my_document.pdf -o /path/to/output/book.mp3
 
 # If the PDF is in another directory:
 python pdf2mp3.py /path/to/your/document.pdf
@@ -59,8 +63,9 @@ python pdf2mp3.py "My Document.pdf"
 The script will:
 1. Convert the PDF to text
 2. Use macOS's text-to-speech engine to create audio
-3. Save the output as an MP3 file in the same directory as the input PDF
-   - For example, if your input is `my_document.pdf`, the output will be `my_document.mp3`
+3. Save the output as an MP3 file (by default next to the input PDF)
+   - For example, if your input is `my_document.pdf`, the default output will
+     be `my_document.mp3`
 
 ## Features
 

--- a/pdf2mp3.py
+++ b/pdf2mp3.py
@@ -10,6 +10,7 @@ import tempfile
 from typing import List
 import shutil
 import importlib
+import argparse
 
 
 def check_ffmpeg() -> None:
@@ -194,11 +195,18 @@ def text_to_speech(text: str, output_path: Path) -> None:
 
 def main() -> None:
     """Main function to convert PDF to MP3."""
-    if len(sys.argv) != 2:
-        print("Usage: python pdf2mp3.py <pdf_file>")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description="Convert a PDF to an MP3 audiobook")
+    parser.add_argument("pdf", type=Path, help="Path to the PDF file to convert")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Path where the MP3 will be saved. Defaults to <pdf>.mp3",
+    )
 
-    pdf_path = Path(sys.argv[1])
+    args = parser.parse_args()
+
+    pdf_path = args.pdf
     if not pdf_path.exists():
         print(f"Error: File {pdf_path} does not exist")
         sys.exit(1)
@@ -215,7 +223,7 @@ def main() -> None:
         text = clean_text(text)
 
         # Convert to speech
-        output_path = pdf_path.with_suffix('.mp3')
+        output_path = args.output if args.output else pdf_path.with_suffix('.mp3')
         text_to_speech(text, output_path)
 
         print(f"Conversion complete! Output saved to: {output_path}")


### PR DESCRIPTION
## Summary
- add argparse and optional `-o/--output` to `pdf2mp3.py`
- document custom output path in README

## Testing
- `python -m py_compile pdf2mp3.py`

------
https://chatgpt.com/codex/tasks/task_e_684070b4f560832ab062352f1a24ab48