### PR TITLE
Improve cross-platform support and download naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDF to MP3 Converter
 
-A Python script that converts PDF files to MP3 audio using macOS's built-in text-to-speech engine.
+A Python script that converts PDF files to MP3 audio using macOS's built-in text-to-speech engine when available, or Google Text-to-Speech on other platforms.
 
 ## 🚀 Quick Start
 
@@ -17,7 +17,7 @@ I was frustrated when I wanted to listen to the Deep Research results within Cha
 ## Requirements
 
 - Python 3.6 or higher
-- macOS (uses the built-in `say` command)
+- macOS is recommended (uses the built-in `say` command when available, with Google Text-to-Speech fallback on other platforms)
 - FFmpeg (required by pydub for audio processing)
 
 ## Installation
@@ -38,7 +38,11 @@ source venv/bin/activate
 
 4. (Alternative) Install FFmpeg if you haven't already:
 ```bash
+# macOS
 brew install ffmpeg
+
+# Debian/Ubuntu
+sudo apt-get install ffmpeg
 ```
 
 ## Usage
@@ -62,7 +66,7 @@ python pdf2mp3.py "My Document.pdf"
 
 The script will:
 1. Convert the PDF to text
-2. Use macOS's text-to-speech engine to create audio
+2. Use macOS's text-to-speech engine (or Google Text-to-Speech on other platforms) to create audio
 3. Save the output as an MP3 file (by default next to the input PDF)
    - For example, if your input is `my_document.pdf`, the default output will
      be `my_document.mp3`
@@ -70,7 +74,7 @@ The script will:
 ## Features
 
 - Handles large PDFs by chunking text into manageable segments
-- Uses macOS's high-quality text-to-speech engine
+- Uses macOS's high-quality text-to-speech engine when available, with gTTS fallback elsewhere
 - Automatically cleans up temporary files
 - Shows progress during conversion
 
@@ -87,7 +91,7 @@ From there you can upload a PDF or paste text and click **Convert** to generate 
 
 ## Note
 
-This script requires macOS as it uses the built-in `say` command for text-to-speech conversion. 
+The script uses the macOS `say` command when available but will automatically fall back to Google Text-to-Speech on other operating systems.
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <h1>PDF/Text to MP3 Converter</h1>
-  <p>Select a PDF or paste text below and click "Convert" to generate an MP3.</p>
+  <p>Select a PDF or paste text below and click "Convert" to generate an MP3. The downloaded file will be named after the PDF you upload.</p>
 
   <div class="uploader">
     <input type="file" id="pdfFile" accept="application/pdf">

--- a/docs/script.js
+++ b/docs/script.js
@@ -34,7 +34,7 @@ async function fetchMP3(chunk) {
   return new Uint8Array(await resp.arrayBuffer());
 }
 
-async function textToMP3(text) {
+async function textToMP3(text, outputName = 'output.mp3') {
   const chunks = chunkText(text);
   const buffers = [];
   const progress = document.getElementById('progress');
@@ -56,6 +56,7 @@ async function textToMP3(text) {
   document.getElementById('audio').src = url;
   const dl = document.getElementById('downloadLink');
   dl.href = url;
+  dl.download = outputName;
   dl.style.display = 'inline-block';
   progress.textContent = 'Done!';
   progressBar.style.display = 'none';
@@ -64,18 +65,20 @@ async function textToMP3(text) {
 async function handleConvert() {
   const file = document.getElementById('pdfFile').files[0];
   let text = document.getElementById('textInput').value.trim();
+  let outputName = 'output.mp3';
   const progressBar = document.getElementById('progressBar');
   progressBar.style.display = 'none';
   progressBar.value = 0;
   if (file) {
     document.getElementById('progress').textContent = 'Extracting text from PDF...';
     text += '\n' + await extractTextFromPDF(file);
+    outputName = file.name.replace(/\.pdf$/i, '.mp3');
   }
   if (!text) {
     alert('Please upload a PDF or enter some text.');
     return;
   }
-  await textToMP3(text);
+  await textToMP3(text, outputName);
 }
 
 document.getElementById('convertBtn').addEventListener('click', handleConvert);

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <h1>PDF/Text to MP3 Converter</h1>
-  <p>Upload a PDF or paste text below and click <strong>Convert</strong>. Your MP3 will appear for playback and download.</p>
+  <p>Upload a PDF or paste text below and click <strong>Convert</strong>. Your MP3 will appear for playback and download. The file name defaults to the uploaded PDF.</p>
 
   <div class="uploader">
     <input type="file" id="pdfFile" accept="application/pdf">

--- a/script.js
+++ b/script.js
@@ -34,7 +34,7 @@ async function fetchMP3(chunk) {
   return new Uint8Array(await resp.arrayBuffer());
 }
 
-async function textToMP3(text) {
+async function textToMP3(text, outputName = 'output.mp3') {
   const chunks = chunkText(text);
   const buffers = [];
   const progress = document.getElementById('progress');
@@ -56,6 +56,7 @@ async function textToMP3(text) {
   document.getElementById('audio').src = url;
   const dl = document.getElementById('downloadLink');
   dl.href = url;
+  dl.download = outputName;
   dl.style.display = 'inline-block';
   progress.textContent = 'Done!';
   progressBar.style.display = 'none';
@@ -64,18 +65,20 @@ async function textToMP3(text) {
 async function handleConvert() {
   const file = document.getElementById('pdfFile').files[0];
   let text = document.getElementById('textInput').value.trim();
+  let outputName = 'output.mp3';
   const progressBar = document.getElementById('progressBar');
   progressBar.style.display = 'none';
   progressBar.value = 0;
   if (file) {
     document.getElementById('progress').textContent = 'Extracting text from PDF...';
     text += '\n' + await extractTextFromPDF(file);
+    outputName = file.name.replace(/\.pdf$/i, '.mp3');
   }
   if (!text) {
     alert('Please upload a PDF or enter some text.');
     return;
   }
-  await textToMP3(text);
+  await textToMP3(text, outputName);
 }
 
 document.getElementById('convertBtn').addEventListener('click', handleConvert);

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,14 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     else
         echo "ffmpeg already installed."
     fi
+elif command -v apt-get &> /dev/null; then
+    if ! command -v ffmpeg &> /dev/null; then
+        echo "Installing ffmpeg with apt..."
+        sudo apt-get update
+        sudo apt-get install -y ffmpeg
+    else
+        echo "ffmpeg already installed."
+    fi
 fi
 
 echo "Setup complete! Activate your environment with: source venv/bin/activate" 


### PR DESCRIPTION
## Summary
- clarify macOS fallback behavior in README
- document apt-based ffmpeg install
- support apt install in setup.sh
- show PDF-based filename in download link
- expose same fix in `docs/` resources

## Testing
- `python -m py_compile pdf2mp3.py`
- `python pdf2mp3.py sample.pdf`

------
https://chatgpt.com/codex/tasks/task_e_684072395e4c832aa3bd93c43ac6e37c