### PR TITLE
Improve dark mode toggle

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -106,9 +106,18 @@ async function handleConvert() {
 
 document.getElementById('convertBtn').addEventListener('click', handleConvert);
 
-const toggle = document.getElementById('themeToggle');
-if (toggle) {
-  toggle.addEventListener('click', () => {
-    document.body.classList.toggle('dark');
-  });
-}
+// Initialize theme toggle and restore saved preference
+document.addEventListener('DOMContentLoaded', () => {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark') {
+    document.body.classList.add('dark');
+  }
+
+  const toggle = document.getElementById('themeToggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+      localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+    });
+  }
+});

--- a/script.js
+++ b/script.js
@@ -106,9 +106,18 @@ async function handleConvert() {
 
 document.getElementById('convertBtn').addEventListener('click', handleConvert);
 
-const toggle = document.getElementById('themeToggle');
-if (toggle) {
-  toggle.addEventListener('click', () => {
-    document.body.classList.toggle('dark');
-  });
-}
+// Initialize theme toggle and restore saved preference
+document.addEventListener('DOMContentLoaded', () => {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark') {
+    document.body.classList.add('dark');
+  }
+
+  const toggle = document.getElementById('themeToggle');
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+      localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- persist dark theme selection in localStorage
- restore theme on page load

## Testing
- `node -c script.js && node -c docs/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68407dd8a73c832aa83597c842eb1176