### PR TITLE
Add web download button for generated MP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ A very small browser interface is included so you can convert files without inst
 https://<username>.github.io/audiobook_maker/
 ```
 
-From there you can upload a PDF or paste text and click **Convert** to generate and download the MP3 directly in your browser. When supported your browser's native speech synthesis will be used for playback. If not available the web app falls back to Google's `translate.googleapis.com` endpoint for text-to-speech so it no longer relies on third-party CORS proxies.
+From there you can upload a PDF or paste text and click **Convert** to generate the audio. A **Download** button appears next to the convert button once the file is ready so you can save the MP3 locally. When supported your browser's native speech synthesis will be used for playback. If not available the web app falls back to Google's `translate.googleapis.com` endpoint for text-to-speech so it no longer relies on third-party CORS proxies.
 
 
 ## Note

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,19 +9,21 @@
 <body>
   <button id="themeToggle" class="theme-toggle">Toggle Dark Mode</button>
   <h1>PDF/Text to MP3 Converter</h1>
-  <p>Select a PDF or paste text below and click "Convert" to generate an MP3. The downloaded file will be named after the PDF you upload.</p>
+  <p>Select a PDF or paste text below and click "Convert" to generate an MP3. When complete a <strong>Download</strong> button appears so you can save the file, which is named after the uploaded PDF.</p>
 
   <div class="uploader">
     <input type="file" id="pdfFile" accept="application/pdf">
     <textarea id="textInput" placeholder="Or paste text here..."></textarea>
-    <button id="convertBtn">Convert</button>
+    <div class="button-row">
+      <button id="convertBtn">Convert</button>
+      <a id="downloadLink" href="#" download="output.mp3" class="button-link" style="display:none;">Download MP3</a>
+    </div>
   </div>
 
   <div id="progress"></div>
   <progress id="progressBar" value="0" max="100" style="display:none;"></progress>
   <pre id="terminal" class="terminal"></pre>
   <audio id="audio" controls style="display:none;"></audio>
-  <a id="downloadLink" href="#" download="output.mp3" style="display:none;">Download MP3</a>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js"></script>

--- a/docs/style.css
+++ b/docs/style.css
@@ -32,6 +32,29 @@ body.dark button {
   gap: 0.5em;
 }
 
+.button-row {
+  display: flex;
+  gap: 0.5em;
+}
+
+.button-row button,
+.button-row .button-link {
+  flex: 1;
+  width: auto;
+}
+
+.button-link {
+  display: none;
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  text-decoration: none;
+  text-align: center;
+}
+
+body.dark .button-link {
+  border-color: #555;
+}
+
 textarea {
   min-height: 150px;
 }

--- a/index.html
+++ b/index.html
@@ -9,19 +9,21 @@
 <body>
   <button id="themeToggle" class="theme-toggle">Toggle Dark Mode</button>
   <h1>PDF/Text to MP3 Converter</h1>
-  <p>Upload a PDF or paste text below and click <strong>Convert</strong>. Your MP3 will appear for playback and download. The file name defaults to the uploaded PDF.</p>
+  <p>Upload a PDF or paste text below and click <strong>Convert</strong>. Once finished a <strong>Download</strong> button will appear so you can save the MP3. The file name defaults to the uploaded PDF.</p>
 
   <div class="uploader">
     <input type="file" id="pdfFile" accept="application/pdf">
     <textarea id="textInput" placeholder="Or paste text here..."></textarea>
-    <button id="convertBtn">Convert</button>
+    <div class="button-row">
+      <button id="convertBtn">Convert</button>
+      <a id="downloadLink" href="#" download="output.mp3" class="button-link" style="display:none;">Download MP3</a>
+    </div>
   </div>
 
   <div id="progress"></div>
   <progress id="progressBar" value="0" max="100" style="display:none;"></progress>
   <pre id="terminal" class="terminal"></pre>
   <audio id="audio" controls style="display:none;"></audio>
-  <a id="downloadLink" href="#" download="output.mp3" style="display:none;">Download MP3</a>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -39,6 +39,29 @@ body.dark button {
   width: 100%;
 }
 
+.button-row {
+  display: flex;
+  gap: 0.5em;
+}
+
+.button-row button,
+.button-row .button-link {
+  flex: 1;
+  width: auto;
+}
+
+.button-link {
+  display: none;
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  text-decoration: none;
+  text-align: center;
+}
+
+body.dark .button-link {
+  border-color: #555;
+}
+
 textarea {
   min-height: 150px;
 }


### PR DESCRIPTION
## Summary
- add dedicated download button next to the Convert button
- style new button and adjust layout
- update text in app pages and README to describe download button

## Testing
- `python3 -m py_compile pdf2mp3.py`


------
https://chatgpt.com/codex/tasks/task_e_684083e88478832a801480c181c16189