### PR TITLE
Add play/pause controls

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,10 @@
   <progress id="progressBar" value="0" max="100" style="display:none;"></progress>
   <pre id="terminal" class="terminal"></pre>
   <audio id="audio" controls style="display:none;"></audio>
+  <div id="playbackControls" class="button-row" style="display:none;">
+    <button id="playBtn">Play</button>
+    <button id="pauseBtn">Pause</button>
+  </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js"></script>

--- a/docs/script.js
+++ b/docs/script.js
@@ -80,6 +80,8 @@ async function textToMP3(text, outputName = 'output.mp3') {
   const url = URL.createObjectURL(blob);
   document.getElementById('audio').style.display = 'block';
   document.getElementById('audio').src = url;
+  const pb = document.getElementById('playbackControls');
+  if (pb) pb.style.display = 'flex';
   const dl = document.getElementById('downloadLink');
   dl.href = url;
   dl.download = outputName;
@@ -133,5 +135,15 @@ document.addEventListener('DOMContentLoaded', () => {
       document.body.classList.toggle('dark');
       localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
     });
+  }
+
+  const audio = document.getElementById('audio');
+  const playBtn = document.getElementById('playBtn');
+  const pauseBtn = document.getElementById('pauseBtn');
+  if (playBtn && audio) {
+    playBtn.addEventListener('click', () => audio.play());
+  }
+  if (pauseBtn && audio) {
+    pauseBtn.addEventListener('click', () => audio.pause());
   }
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -78,3 +78,7 @@ textarea {
 body.dark .terminal {
   background: #222;
 }
+
+#playbackControls {
+  margin-top: 0.5em;
+}

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
   <progress id="progressBar" value="0" max="100" style="display:none;"></progress>
   <pre id="terminal" class="terminal"></pre>
   <audio id="audio" controls style="display:none;"></audio>
+  <div id="playbackControls" class="button-row" style="display:none;">
+    <button id="playBtn">Play</button>
+    <button id="pauseBtn">Pause</button>
+  </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js"></script>

--- a/script.js
+++ b/script.js
@@ -80,6 +80,8 @@ async function textToMP3(text, outputName = 'output.mp3') {
   const url = URL.createObjectURL(blob);
   document.getElementById('audio').style.display = 'block';
   document.getElementById('audio').src = url;
+  const pb = document.getElementById('playbackControls');
+  if (pb) pb.style.display = 'flex';
   const dl = document.getElementById('downloadLink');
   dl.href = url;
   dl.download = outputName;
@@ -133,5 +135,15 @@ document.addEventListener('DOMContentLoaded', () => {
       document.body.classList.toggle('dark');
       localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
     });
+  }
+
+  const audio = document.getElementById('audio');
+  const playBtn = document.getElementById('playBtn');
+  const pauseBtn = document.getElementById('pauseBtn');
+  if (playBtn && audio) {
+    playBtn.addEventListener('click', () => audio.play());
+  }
+  if (pauseBtn && audio) {
+    pauseBtn.addEventListener('click', () => audio.pause());
   }
 });

--- a/style.css
+++ b/style.css
@@ -85,3 +85,7 @@ textarea {
 body.dark .terminal {
   background: #222;
 }
+
+#playbackControls {
+  margin-top: 0.5em;
+}


### PR DESCRIPTION
## Summary
- add custom play/pause controls next to the audio element
- expose controls once MP3 is produced
- hook up buttons to the audio element
- style playback controls

## Testing
- `python -m py_compile pdf2mp3.py`

------
https://chatgpt.com/codex/tasks/task_e_6840861990d4832a8b276cca473022a0