### PR TITLE
Fix broken buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ The script will:
 
 ## GitHub Pages Web App
 
-A very small browser interface is included so you can convert files without installing anything. Enable GitHub Pages for the repository (either from the root or the `docs/` folder) and open:
+A very small browser interface is included so you can extract and listen to PDF text without installing anything. Enable GitHub Pages for the repository (either from the root or the `docs/` folder) and open:
 
 ```
 https://<username>.github.io/audiobook_maker/
 ```
 If you're running locally without GitHub Pages, simply open `docs/index.html` in your browser.
 
- From there you can upload a PDF or paste text and click **Convert** to generate the audio. A **Download** button appears next to the convert button once the file is ready so you can save the result locally. The page first attempts to capture audio using your browser's built‑in speech synthesis so the same voice can be downloaded. If that isn't possible it falls back to Google's `translate.googleapis.com` service. Press **Play** after conversion to listen in your browser.
+The page lets you **Extract PDF Text**, **Listen to Text**, and **Download Text**. Use the `pdf2mp3.py` script locally if you want an MP3 download. Browser playback uses the built‑in speech synthesis engine when available and falls back to Google's `translate.googleapis.com` service.
 
 The voice selector now defaults to the first available English voice when the web page loads.
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -184,7 +184,10 @@ async function handleConvert() {
   }
 }
 
-document.getElementById('convertBtn').addEventListener('click', handleConvert);
+const convertBtn = document.getElementById('convertBtn');
+if (convertBtn) {
+  convertBtn.addEventListener('click', handleConvert);
+}
 
 // Initialize theme toggle and restore saved preference
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- guard missing Convert button
- update README instructions for the web app

## Testing
- `python -m py_compile pdf2mp3.py`
- `ffmpeg -version | head -n 3`
- `python pdf2mp3.py test.pdf -o out.mp3`

------
https://chatgpt.com/codex/tasks/task_e_684097ca7174832a89f5780d8cdd021e