### PR TITLE
Add MP3 instructions and button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ source venv/bin/activate
 python pdf2mp3.py my_document.pdf
 ```
 
+### Convert a PDF in a Few Steps
+
+1. Place your PDF in the same folder as `pdf2mp3.py`.
+2. Open a terminal and run `python pdf2mp3.py yourfile.pdf`.
+3. You'll get `yourfile.mp3` voiced by your operating system.
+
 I was frustrated when I wanted to listen to the Deep Research results within ChatGPT, since all of the "free text to speech" providers severely capped my characters or hours. So now we can all listen to whatever we want.
 
 ## Requirements

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,7 @@
       <button id="extractBtn">Extract PDF Text</button>
       <button id="listenBtn">Listen to Text</button>
       <button id="downloadTextBtn">Download Text</button>
+      <button id="convertBtn">Download MP3</button>
     </div>
   </div>
   <div id="progress"></div>
@@ -29,6 +30,18 @@
     <button id="pauseListenBtn">Pause</button>
     <button id="resumeListenBtn">Resume</button>
     <button id="stopListenBtn">Stop</button>
+  </div>
+
+  <div id="mp3Help" style="display:none;" class="instructions">
+    <h2>How to Generate an MP3</h2>
+    <ol>
+      <li>Download <code>pdf2mp3.py</code> from this repository.</li>
+      <li>Open a terminal in the folder where your PDF lives.</li>
+      <li>Run <code>python pdf2mp3.py yourfile.pdf</code>.</li>
+      <li>The script will create <code>yourfile.mp3</code> using your system's
+      voices.</li>
+    </ol>
+    <p>See the project README for setup instructions if Python or FFmpeg are not installed.</p>
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>

--- a/docs/script.js
+++ b/docs/script.js
@@ -186,7 +186,10 @@ async function handleConvert() {
 
 const convertBtn = document.getElementById('convertBtn');
 if (convertBtn) {
-  convertBtn.addEventListener('click', handleConvert);
+  convertBtn.addEventListener('click', () => {
+    const help = document.getElementById('mp3Help');
+    if (help) help.style.display = help.style.display === 'none' ? 'block' : 'none';
+  });
 }
 
 // Initialize theme toggle and restore saved preference

--- a/docs/style.css
+++ b/docs/style.css
@@ -101,3 +101,13 @@ body.dark .terminal {
   min-width: 2em;
   text-align: right;
 }
+
+.instructions {
+  margin-top: 1em;
+  border: 1px solid #ccc;
+  padding: 0.5em;
+}
+
+body.dark .instructions {
+  border-color: #555;
+}


### PR DESCRIPTION
## Summary
- add button in web UI for MP3 download instructions
- show simple usage steps for the script
- hide or show instructions with JavaScript
- style instruction panel

## Testing
- `python pdf2mp3.py --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840a1991d20832aa0295da73dd22e31