### PR TITLE
Enhance web instructions for MP3 generation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,9 +36,19 @@
     <h2>How to Generate an MP3</h2>
     <ol>
       <li>Download the project as a ZIP and unzip it.</li>
-      <li>Open a terminal in the unzipped folder.</li>
-      <li>Run <code>python pdf2mp3.py</code>.</li>
-      <li>The script will find the PDF and create an MP3 for you.</li>
+      <li>
+        Open a terminal in the unzipped folder.
+        <ul>
+          <li><strong>Windows:</strong> launch <em>Command Prompt</em> from the Start menu.</li>
+          <li><strong>macOS:</strong> open <em>Terminal</em> from <em>Applications &gt; Utilities</em> or use Spotlight.</li>
+          <li><strong>Linux:</strong> press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> or find <em>Terminal</em> in your applications menu.</li>
+        </ul>
+      </li>
+      <li>
+        Run <code id="cmdText">python pdf2mp3.py</code>
+        <button id="copyCmdBtn" type="button">Copy</button>.
+      </li>
+      <li>The script will find the PDF and create an MP3 for you. When it finishes, the file automatically downloads.</li>
     </ol>
     <p>No need to look anywhere else&mdash;this one command makes your MP3.</p>
   </div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -229,6 +229,17 @@ document.addEventListener('DOMContentLoaded', () => {
       rateVal.textContent = rate.value;
     });
   }
+
+  const copyBtn = document.getElementById('copyCmdBtn');
+  const cmdText = document.getElementById('cmdText');
+  if (copyBtn && cmdText && navigator.clipboard) {
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(cmdText.textContent.trim()).then(() => {
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+      });
+    });
+  }
 });
 
 // Listen to text using browser TTS

--- a/docs/style.css
+++ b/docs/style.css
@@ -111,3 +111,8 @@ body.dark .terminal {
 body.dark .instructions {
   border-color: #555;
 }
+
+#copyCmdBtn {
+  margin-left: 0.5em;
+  padding: 0.25em 0.5em;
+}


### PR DESCRIPTION
## Summary
- update mp3 instructions with OS-specific terminal tips
- add a copy button for the `python pdf2mp3.py` command
- tweak styles for the new button
- wire up clipboard copy logic in the web UI

## Testing
- `python3 -m py_compile pdf2mp3.py`


------
https://chatgpt.com/codex/tasks/task_e_6840a889fa5c832ab6b71de4890a448e