### PR TITLE
Improve zip instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python pdf2mp3.py my_document.pdf
 Follow these steps to turn a PDF into an MP3. Make sure Python and FFmpeg are installed on your computer.
 
 1. Click **Code** and choose **Download ZIP** to get the files, or use the page's "Download MP3" button to generate the archive in your browser.
-2. Open the ZIP you downloaded. A new folder appears (your PDF is already inside).
+2. Open the ZIP you downloaded. A new folder appears. Move your PDF into this folder.
 3. Open Command Prompt on Windows or Terminal on Mac and Linux.
 4. Type `cd `, drag the folder into the window, and press **Enter**.
 5. Type `python pdf2mp3.py` and press **Enter**. The script finds the PDF for you.

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
   <div id="mp3Help" style="display:none;" class="instructions">
     <h2>How to Generate an MP3</h2>
     <ol>
-      <li>The project ZIP is generated in your browser and downloads automatically. Unzip it when finished.</li>
+      <li>The project ZIP downloads automatically. Unzip it, then place your PDF in the folder.</li>
       <li>
         Open a terminal in the unzipped folder.
         <ul>


### PR DESCRIPTION
## Summary
- clarify that the downloaded zip does not include the PDF
- update browser instructions with the same note

## Testing
- `python -m py_compile pdf2mp3.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b2d3ab18832aba3e1f8bb37684ad