### PR TITLE
Improve copy command path in web instructions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,7 @@
         </ul>
       </li>
       <li>
-        Run <code id="cmdText">python pdf2mp3.py</code>
+        Run <code id="cmdText">python ~/Downloads/audiobook_maker/pdf2mp3.py</code>
         <button id="copyCmdBtn" type="button">Copy</button>.
       </li>
       <li>The script will find the PDF and create an MP3 for you. When it finishes, the file automatically downloads.</li>

--- a/docs/script.js
+++ b/docs/script.js
@@ -202,10 +202,22 @@ function downloadZip() {
   URL.revokeObjectURL(url);
 }
 
+function setCmdPath() {
+  const cmdText = document.getElementById('cmdText');
+  if (!cmdText) return;
+  const ua = (navigator.userAgent || navigator.platform || '').toLowerCase();
+  if (ua.includes('win')) {
+    cmdText.textContent = 'python %USERPROFILE%\\Downloads\\audiobook_maker\\pdf2mp3.py';
+  } else {
+    cmdText.textContent = 'python ~/Downloads/audiobook_maker/pdf2mp3.py';
+  }
+}
+
 const convertBtn = document.getElementById('convertBtn');
 if (convertBtn) {
   convertBtn.addEventListener('click', () => {
     downloadZip();
+    setCmdPath();
     const help = document.getElementById('mp3Help');
     if (help) help.style.display = 'block';
   });
@@ -248,6 +260,8 @@ document.addEventListener('DOMContentLoaded', () => {
       rateVal.textContent = rate.value;
     });
   }
+
+  setCmdPath();
 
   const copyBtn = document.getElementById('copyCmdBtn');
   const cmdText = document.getElementById('cmdText');


### PR DESCRIPTION
## Summary
- update help instructions to include default download path
- add helper in script.js to copy the correct command on all OSes

## Testing
- `python -m py_compile pdf2mp3.py`
- `node --check docs/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6840ba88837c832a97f9a8e61917ad99