### PR TITLE
Display MP3 instructions immediately

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
     <button id="stopListenBtn">Stop</button>
   </div>
 
-  <div id="mp3Help" style="display:none;" class="instructions">
+  <div id="mp3Help" class="instructions">
     <h2>How to Generate an MP3</h2>
     <ol>
       <li>The project ZIP downloads automatically. Unzip it, then place your PDF in the folder.</li>


### PR DESCRIPTION
## Summary
- always show MP3 conversion instructions on the web page

## Testing
- `python3 -m py_compile pdf2mp3.py`


------
https://chatgpt.com/codex/tasks/task_e_6840bbce7af4832aab2ce24ca6dda66f