### PR TITLE
Handle missing requirements file gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bash setup.sh
 source venv/bin/activate
 ```
 
-3. (Alternative) Manual install: The script will automatically install required Python packages on first run.
+3. (Alternative) Manual install: The script will automatically install required Python packages on first run, even if ``requirements.txt`` isn't present.
 
 4. (Alternative) Install FFmpeg if you haven't already:
 ```bash

--- a/pdf2mp3.py
+++ b/pdf2mp3.py
@@ -29,10 +29,13 @@ def check_and_install_dependencies() -> None:
         importlib.import_module("pydub")
     except ImportError:
         print("Installing required dependencies...")
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
-        )
-
+        req_file = Path(__file__).with_name("requirements.txt")
+        cmd = [sys.executable, "-m", "pip", "install"]
+        if req_file.exists():
+            cmd.extend(["-r", str(req_file)])
+        else:
+            cmd.extend(["PyPDF2", "pydub", "gTTS", "pyttsx3"])
+        subprocess.check_call(cmd)
         print("Dependencies installed successfully!")
 
 


### PR DESCRIPTION
## Summary
- fallback install dependencies if `requirements.txt` is missing
- clarify README instructions on automatic installs

## Testing
- `python -m py_compile pdf2mp3.py`
- `python pdf2mp3.py -h | head`

------
https://chatgpt.com/codex/tasks/task_e_6840d419334c832aa695fd23eb96b53f