### PR TITLE
Fix PDF extraction and enable dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,8 @@
   <title>PDF/Text to Speech</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="dark-mode">
+  <button id="themeToggle" class="theme-toggle">Toggle Light/Dark</button>
   <h1>PDF/Text to Speech</h1>
   <div class="uploader">
     <input type="file" id="pdfFile" accept="application/pdf">

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,3 +1,6 @@
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
+
 async function extractTextFromPDF(file) {
   const bytes = new Uint8Array(await file.arrayBuffer());
   const pdf = await pdfjsLib.getDocument({ data: bytes }).promise;
@@ -45,8 +48,13 @@ document.getElementById('extractBtn').addEventListener('click', async () => {
     alert('Please select a PDF file.');
     return;
   }
-  const text = await extractTextFromPDF(file);
-  document.getElementById('textInput').value = text;
+  try {
+    const text = await extractTextFromPDF(file);
+    document.getElementById('textInput').value = text;
+  } catch (err) {
+    console.error(err);
+    alert('Failed to extract text from PDF.');
+  }
 });
 
 document.getElementById('listenBtn').addEventListener('click', () => {
@@ -61,3 +69,8 @@ document.getElementById('listenBtn').addEventListener('click', () => {
 document.getElementById('pauseBtn').addEventListener('click', pauseSpeech);
 document.getElementById('resumeBtn').addEventListener('click', resumeSpeech);
 document.getElementById('stopBtn').addEventListener('click', stopSpeech);
+
+// Toggle light/dark mode
+document.getElementById('themeToggle').addEventListener('click', () => {
+  document.body.classList.toggle('dark-mode');
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,10 +5,29 @@ body {
   padding: 1em;
 }
 
+body.dark-mode {
+  background-color: #121212;
+  color: #eee;
+}
+
+body.dark-mode input,
+body.dark-mode textarea,
+body.dark-mode button {
+  background-color: #333;
+  border-color: #555;
+  color: #eee;
+}
+
+.theme-toggle {
+  margin-bottom: 1em;
+  float: right;
+}
+
 .uploader {
   display: flex;
   flex-direction: column;
   gap: 0.5em;
+  margin-top: 1em;
 }
 
 .uploader input,
@@ -19,6 +38,10 @@ body {
   padding: 0.5em;
   border-radius: 0.25em;
   border: 1px solid #ccc;
+}
+
+.uploader textarea {
+  min-height: 10em;
 }
 
 .button-row {


### PR DESCRIPTION
## Summary
- enable dark-mode styling and toggle
- add error handling when extracting text from PDF
- default the page to dark mode
- configure pdf.js worker path

## Testing
- `node --check docs/script.js`
- `python -m py_compile pdf2mp3.py server/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684330fec524832abbcff8381a1ad421