### PR TITLE
Add terminal log display

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,7 @@
     <button id="resumeBtn">Resume</button>
     <button id="stopBtn">Stop</button>
   </div>
+  <pre id="terminalOutput" class="terminal"></pre>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js"></script>
   <script src="script.js"></script>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,16 +1,26 @@
 pdfjsLib.GlobalWorkerOptions.workerSrc =
   'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
 
+const terminalOutput = document.getElementById('terminalOutput');
+function log(message) {
+  if (!terminalOutput) return;
+  terminalOutput.textContent += message + '\n';
+  terminalOutput.scrollTop = terminalOutput.scrollHeight;
+}
+
 async function extractTextFromPDF(file) {
   const bytes = new Uint8Array(await file.arrayBuffer());
   const pdf = await pdfjsLib.getDocument({ data: bytes }).promise;
   let text = '';
+  log(`Extracting text from PDF with ${pdf.numPages} pages...`);
   for (let page = 1; page <= pdf.numPages; page++) {
     const pageObj = await pdf.getPage(page);
     const content = await pageObj.getTextContent();
     const strings = content.items.map(it => it.str);
     text += strings.join(' ') + '\n';
+    log(`Extracted page ${page}/${pdf.numPages}`);
   }
+  log('Finished extracting PDF text.');
   return text;
 }
 
@@ -27,7 +37,11 @@ function speakText(text) {
   utter.onend = () => {
     document.getElementById('controls').style.display = 'none';
     currentUtterance = null;
+    log('Speech finished.');
   };
+  utter.onstart = () => log('Speech started.');
+  utter.onpause = () => log('Speech paused.');
+  utter.onresume = () => log('Speech resumed.');
   window.speechSynthesis.speak(utter);
   document.getElementById('controls').style.display = 'flex';
 }
@@ -39,6 +53,7 @@ function stopSpeech() {
     speechSynthesis.cancel();
     currentUtterance = null;
     document.getElementById('controls').style.display = 'none';
+    log('Speech stopped.');
   }
 }
 
@@ -53,6 +68,7 @@ document.getElementById('extractBtn').addEventListener('click', async () => {
     document.getElementById('textInput').value = text;
   } catch (err) {
     console.error(err);
+    log('Failed to extract text from PDF.');
     alert('Failed to extract text from PDF.');
   }
 });
@@ -63,6 +79,7 @@ document.getElementById('listenBtn').addEventListener('click', () => {
     alert('Enter or extract some text first.');
     return;
   }
+  log('Starting text to speech...');
   speakText(text);
 });
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -56,3 +56,15 @@ body.dark-mode button {
 #controls {
   margin-top: 0.5em;
 }
+
+.terminal {
+  background-color: #000;
+  color: #0f0;
+  font-family: monospace;
+  padding: 0.5em;
+  margin-top: 1em;
+  max-height: 200px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  border-radius: 0.25em;
+}


### PR DESCRIPTION
## Summary
- show a terminal-style element at the bottom of the page
- style terminal output to look like a command line
- stream progress to the terminal during PDF extraction and speech events

## Testing
- `python -m py_compile pdf2mp3.py server/app.py`
- `node --check docs/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6843322fc8e8832a9a5e2606aeaf311b