### PR TITLE
Rename project to PDF Text Extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Browser PDF/Text Reader
+# PDF Text Extractor
 
 This repository contains a lightweight web page that reads text aloud using your browser's native speech synthesis.
 
@@ -9,4 +9,5 @@ This repository contains a lightweight web page that reads text aloud using your
 3. Click **Extract PDF Text** to load the PDF and **Listen** to hear it spoken.
 4. Use **Pause**, **Resume** and **Stop** to control playback.
 
-That's it!
+You can also use the command-line script `pdf_text_extractor.py` to convert a PDF to an MP3 audiobook.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PDF/Text to Speech</title>
+  <title>PDF Text Extractor</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="dark-mode">
   <button id="themeToggle" class="theme-toggle">Toggle Light/Dark</button>
-  <h1>PDF/Text to Speech</h1>
+  <h1>PDF Text Extractor</h1>
   <div class="uploader">
     <input type="file" id="pdfFile" accept="application/pdf">
     <textarea id="textInput" placeholder="Paste text or extract from PDF..."></textarea>

--- a/pdf_text_extractor.py
+++ b/pdf_text_extractor.py
@@ -277,8 +277,8 @@ def main() -> None:
             print(f"Using detected PDF: {pdf_path}")
         elif len(unique_pdfs) == 0:
             print(
-                "Error: No PDF found. Move your document next to pdf2mp3.py "
-                "or run 'python pdf2mp3.py <file>'."
+                "Error: No PDF found. Move your document next to pdf_text_extractor.py "
+                "or run 'python pdf_text_extractor.py <file>'."
             )
             sys.exit(1)
         else:

--- a/server/app.py
+++ b/server/app.py
@@ -6,16 +6,16 @@ from pathlib import Path
 from flask import Flask, request, send_file, after_this_request
 from flask_cors import CORS
 
-import pdf2mp3
+import pdf_text_extractor
 
-pdf2mp3.check_and_install_dependencies()
-pdf2mp3.check_ffmpeg()
+pdf_text_extractor.check_and_install_dependencies()
+pdf_text_extractor.check_ffmpeg()
 
-pdf2mp3.TTS_ENGINE = pdf2mp3.determine_tts_engine()
+pdf_text_extractor.TTS_ENGINE = pdf_text_extractor.determine_tts_engine()
 from PyPDF2 import PdfReader as _PdfReader  # type: ignore
 from pydub import AudioSegment as _AudioSegment  # type: ignore
-pdf2mp3.PdfReader = _PdfReader
-pdf2mp3.AudioSegment = _AudioSegment
+pdf_text_extractor.PdfReader = _PdfReader
+pdf_text_extractor.AudioSegment = _AudioSegment
 
 app = Flask(__name__)
 CORS(app)
@@ -31,13 +31,13 @@ def convert():
         uploaded.save(pdf_tmp.name)
         pdf_path = Path(pdf_tmp.name)
 
-    text = pdf2mp3.extract_text_from_pdf(pdf_path)
-    text = pdf2mp3.clean_text(text)
+    text = pdf_text_extractor.extract_text_from_pdf(pdf_path)
+    text = pdf_text_extractor.clean_text(text)
 
     mp3_tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.mp3')
     mp3_tmp.close()
     mp3_path = Path(mp3_tmp.name)
-    pdf2mp3.text_to_speech(text, mp3_path)
+    pdf_text_extractor.text_to_speech(text, mp3_path)
 
     @after_this_request
     def cleanup(response):


### PR DESCRIPTION
## Summary
- rename project references from `audiobook_maker` to **PDF Text Extractor**
- rename `pdf2mp3.py` script to `pdf_text_extractor.py`
- update Flask server imports to use the new script name
- adjust README and docs titles accordingly

## Testing
- `python -m py_compile pdf_text_extractor.py server/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685ad7880d70832aa3940c8ea25affe0